### PR TITLE
FEATURE: Add support for custom icon url

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -24,3 +24,7 @@
     }
   }
 }
+
+.custom-header-icon-link img {
+  width: 100%;
+}

--- a/javascripts/discourse/initializers/initialize-for-header-icon-links.js
+++ b/javascripts/discourse/initializers/initialize-for-header-icon-links.js
@@ -1,6 +1,24 @@
 import { withPluginApi } from "discourse/lib/plugin-api";
 import { iconNode } from "discourse-common/lib/icon-library";
 import { dasherize } from "@ember/string";
+import isValidUrl from "../lib/isValidUrl";
+import { h } from "virtual-dom";
+
+function buildIcon(icon) {
+  if (isValidUrl(icon)) {
+    return h(
+      "img",
+      {
+        attributes: {
+          src: icon,
+        },
+      },
+      ""
+    );
+  } else {
+    return iconNode(icon.toLowerCase());
+  }
+}
 
 export default {
   name: "header-icon-links",
@@ -12,7 +30,7 @@ export default {
         splitLinks.forEach((link, index, links) => {
           const fragments = link.split(",").map((fragment) => fragment.trim());
           const title = fragments[0];
-          const icon = iconNode(fragments[1].toLowerCase());
+          const icon = buildIcon(fragments[1]);
           const href = fragments[2];
           const className = `header-icon-${dasherize(fragments[0])}`;
           const viewClass = fragments[3].toLowerCase();

--- a/javascripts/discourse/lib/isValidUrl.js
+++ b/javascripts/discourse/lib/isValidUrl.js
@@ -1,6 +1,6 @@
 export default function isValidUrl(string) {
   try {
-    new URL(string);
+    URL(string);
   } catch (_) {
     return false;
   }

--- a/javascripts/discourse/lib/isValidUrl.js
+++ b/javascripts/discourse/lib/isValidUrl.js
@@ -1,0 +1,11 @@
+export default function isValidUrl(string) {
+  let url;
+
+  try {
+    url = new URL(string);
+  } catch (_) {
+    return false;
+  }
+
+  return true;
+}

--- a/javascripts/discourse/lib/isValidUrl.js
+++ b/javascripts/discourse/lib/isValidUrl.js
@@ -1,8 +1,6 @@
 export default function isValidUrl(string) {
-  let url;
-
   try {
-    url = new URL(string);
+    new URL(string);
   } catch (_) {
     return false;
   }


### PR DESCRIPTION
This PR adds support for adding a custom icon through a URL so that you can add icons from sources other than Font Awesome.

<img width="464" alt="Screen Shot 2022-09-16 at 9 33 14 AM" src="https://user-images.githubusercontent.com/30090424/190687117-5b3479e9-7b6d-4c85-b79b-6abd044f1310.png">

Fulfills a request such as the one mentioned on Meta here:
https://meta.discourse.org/t/how-to-use-my-own-svg-icons-in-custom-header-links-theme-component/238196
