### PR TITLE
FIX: URL needs explicit instantiation

### DIFF
--- a/javascripts/discourse/lib/isValidUrl.js
+++ b/javascripts/discourse/lib/isValidUrl.js
@@ -1,6 +1,12 @@
 export default function isValidUrl(string) {
+  let url;
+
   try {
-    URL(string);
+    url = new URL(string);
+
+    if (url) {
+      return true;
+    }
   } catch (_) {
     return false;
   }

--- a/javascripts/discourse/lib/isValidUrl.js
+++ b/javascripts/discourse/lib/isValidUrl.js
@@ -1,8 +1,6 @@
 export default function isValidUrl(string) {
-  let url;
-
   try {
-    url = new URL(string);
+    const url = new URL(string);
 
     if (url) {
       return true;


### PR DESCRIPTION
This PR fixes an issue where url based icons are not working due to `isValidUrl()` method not working correctly since URL class is not instantiated explicitly.