### PR TITLE
DEV: Refactor icon links to use Glimmer templates

### DIFF
--- a/javascripts/discourse/initializers/initialize-for-header-icon-links.gjs
+++ b/javascripts/discourse/initializers/initialize-for-header-icon-links.gjs
@@ -3,13 +3,14 @@ import icon from "discourse-common/helpers/d-icon";
 import { dasherize } from "@ember/string";
 import isValidUrl from "../lib/isValidUrl";
 
-function buildIcon(iconNameOrImageUrl) {
+function buildIcon(iconNameOrImageUrl, title) {
   if (isValidUrl(iconNameOrImageUrl)) {
     return <template>
       <img src="{{iconNameOrImageUrl}}" aria-hidden="true"/>
+      <span class="sr-only">{{title}}</span>
     </template>
   } else {
-    return <template>{{icon iconNameOrImageUrl}}</template>
+    return <template>{{icon iconNameOrImageUrl label=title}}</template>
   }
 }
 
@@ -23,7 +24,7 @@ export default {
         splitLinks.forEach((link, index, links) => {
           const fragments = link.split(",").map((fragment) => fragment.trim());
           const title = fragments[0];
-          const iconTemplate = buildIcon(fragments[1]);
+          const iconTemplate = buildIcon(fragments[1], title);
           const href = fragments[2];
           const className = `header-icon-${dasherize(fragments[0])}`;
           const viewClass = fragments[3].toLowerCase();

--- a/javascripts/discourse/initializers/initialize-for-header-icon-links.gjs
+++ b/javascripts/discourse/initializers/initialize-for-header-icon-links.gjs
@@ -1,8 +1,7 @@
 import { withPluginApi } from "discourse/lib/plugin-api";
-import { iconHTML } from "discourse-common/lib/icon-library";
+import icon from "discourse-common/helpers/d-icon";
 import { dasherize } from "@ember/string";
 import isValidUrl from "../lib/isValidUrl";
-import { htmlSafe } from "@ember/template";
 
 function buildIcon(iconNameOrImageUrl) {
   if (isValidUrl(iconNameOrImageUrl)) {
@@ -10,7 +9,7 @@ function buildIcon(iconNameOrImageUrl) {
       <img src="{{iconNameOrImageUrl}}"/>
     </template>
   } else {
-    return htmlSafe(iconHTML(iconNameOrImageUrl.toLowerCase()));
+    return <template>{{icon iconNameOrImageUrl }}</template>
   }
 }
 
@@ -24,7 +23,7 @@ export default {
         splitLinks.forEach((link, index, links) => {
           const fragments = link.split(",").map((fragment) => fragment.trim());
           const title = fragments[0];
-          const icon = buildIcon(fragments[1]);
+          const iconTemplate = buildIcon(fragments[1]);
           const href = fragments[2];
           const className = `header-icon-${dasherize(fragments[0])}`;
           const viewClass = fragments[3].toLowerCase();
@@ -41,7 +40,7 @@ export default {
               target="{{target}}"
               rel="{{rel}}"
               >
-                {{icon}}
+                {{iconTemplate}}
               </a>
             </li>
           </template>

--- a/javascripts/discourse/initializers/initialize-for-header-icon-links.gjs
+++ b/javascripts/discourse/initializers/initialize-for-header-icon-links.gjs
@@ -1,22 +1,16 @@
 import { withPluginApi } from "discourse/lib/plugin-api";
-import { iconNode } from "discourse-common/lib/icon-library";
+import { iconHTML } from "discourse-common/lib/icon-library";
 import { dasherize } from "@ember/string";
 import isValidUrl from "../lib/isValidUrl";
-import { h } from "virtual-dom";
+import { htmlSafe } from "@ember/template";
 
-function buildIcon(icon) {
-  if (isValidUrl(icon)) {
-    return h(
-      "img",
-      {
-        attributes: {
-          src: icon,
-        },
-      },
-      ""
-    );
+function buildIcon(iconNameOrImageUrl) {
+  if (isValidUrl(iconNameOrImageUrl)) {
+    return <template>
+      <img src="{{iconNameOrImageUrl}}"/>
+    </template>
   } else {
-    return iconNode(icon.toLowerCase());
+    return htmlSafe(iconHTML(iconNameOrImageUrl.toLowerCase()));
   }
 }
 
@@ -38,24 +32,23 @@ export default {
           const rel = target ? "noopener" : "";
           const isLastLink =
             link === links[links.length - 1] ? ".last-custom-icon" : "";
-          const selector = `li.custom-header-icon-link.${className}.${viewClass}${isLastLink}`;
 
-          api.decorateWidget("header-icons:before", (helper) => {
-            return helper.h(selector, [
-              helper.h(
-                "a.icon.btn-flat",
-                {
-                  href,
-                  title,
-                  target,
-                  attributes: {
-                    rel,
-                  },
-                },
-                icon
-              ),
-            ]);
-          });
+          const iconComponent = <template>
+            <li class="custom-header-icon-link {{className}} {{viewClass}} {{isLastLink}}">
+              <a class="icon btn-flat"
+              href="{{href}}"
+              title="{{title}}"
+              target="{{target}}"
+              rel="{{rel}}"
+              >
+                {{icon}}
+              </a>
+            </li>
+          </template>
+
+          const beforeIcon = ['chat', 'search', 'hamburger', 'user-menu']
+
+          api.headerIcons.add(title, iconComponent, { before: beforeIcon })
         });
       } catch (error) {
         // eslint-disable-next-line no-console

--- a/javascripts/discourse/initializers/initialize-for-header-icon-links.gjs
+++ b/javascripts/discourse/initializers/initialize-for-header-icon-links.gjs
@@ -31,7 +31,7 @@ export default {
           const target = fragments[4].toLowerCase() === "blank" ? "_blank" : "";
           const rel = target ? "noopener" : "";
           const isLastLink =
-            link === links[links.length - 1] ? ".last-custom-icon" : "";
+            link === links[links.length - 1] ? "last-custom-icon" : "";
 
           const iconComponent = <template>
             <li class="custom-header-icon-link {{className}} {{viewClass}} {{isLastLink}}">

--- a/javascripts/discourse/initializers/initialize-for-header-icon-links.gjs
+++ b/javascripts/discourse/initializers/initialize-for-header-icon-links.gjs
@@ -9,7 +9,7 @@ function buildIcon(iconNameOrImageUrl) {
       <img src="{{iconNameOrImageUrl}}" aria-hidden="true"/>
     </template>
   } else {
-    return <template>{{icon iconNameOrImageUrl }}</template>
+    return <template>{{icon iconNameOrImageUrl}}</template>
   }
 }
 
@@ -35,10 +35,10 @@ export default {
           const iconComponent = <template>
             <li class="custom-header-icon-link {{className}} {{viewClass}} {{isLastLink}}">
               <a class="icon btn-flat"
-              href="{{href}}"
-              title="{{title}}"
-              target="{{target}}"
-              rel="{{rel}}"
+              href={{href}}
+              title={{title}}
+              target={{target}}
+              rel={{rel}}
               >
                 {{iconTemplate}}
               </a>

--- a/javascripts/discourse/initializers/initialize-for-header-icon-links.gjs
+++ b/javascripts/discourse/initializers/initialize-for-header-icon-links.gjs
@@ -6,7 +6,7 @@ import isValidUrl from "../lib/isValidUrl";
 function buildIcon(iconNameOrImageUrl) {
   if (isValidUrl(iconNameOrImageUrl)) {
     return <template>
-      <img src="{{iconNameOrImageUrl}}"/>
+      <img src="{{iconNameOrImageUrl}}" aria-hidden="true"/>
     </template>
   } else {
     return <template>{{icon iconNameOrImageUrl }}</template>


### PR DESCRIPTION
The site header was refactored to a Glimmer component, which does not support the previous `decorateWidget` API. Refactor icon links to use Glimmer templates and the `headerIcons.add` API instead.