### PR TITLE
DEV: migrates Header_links setting to an object

### DIFF
--- a/javascripts/discourse/initializers/initialize-for-header-icon-links.gjs
+++ b/javascripts/discourse/initializers/initialize-for-header-icon-links.gjs
@@ -21,7 +21,7 @@ export default {
     withPluginApi("0.8.41", (api) => {
       try {
         const site = api.container.lookup("service:site");
-        let links = settings.Header_links;
+        let links = settings.header_links;
         if (site.mobileView) {
           links = links.filter(
             (link) => link.view === "vmo" || link.view === "vdm"

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,0 +1,28 @@
+en:
+  theme_metadata:
+    custom_header_links: "Comma delimited in this order: link text, link title, URL, view, target, hide on scroll<br><b>Link text:</b> The text for the link<br><b>Link title:</b> the text that shows when the link is hovered<br><b>URL:</b> The path for the link (can be relative)<br><b>View:</b> vdm = desktop and mobile, vdo = desktop only, vmo = mobile only<br><b>Target:</b> blank = opens in a new tab, self = opens in the same tab<br><b>Hide on scroll:</b> remove = hides the link when the title is expanded on topic pages keep = keeps the link visible even when the title is visible on topic pages<br><b>Language:</b> blank = no locale assoaciated to the link, else insert a locale code (en, fr, de, ...)"
+    settings:
+      Header_links:
+        description: Custom links to be displayed in the header
+        schema:
+          properties:
+            title:
+              label: Title
+              description: The title attribute for the link
+            icon:
+              label: Icon
+              description: The icon used for the link
+            url:
+              label: URL
+              description: The URL for the link
+            view:
+              label: View
+              description: |
+                vdm = desktop and mobile
+                vdo = desktop only
+                vmo = mobile only
+            target:
+              label: Target
+              description: |
+                blank = opens in a new tab
+                self = opens in the same tab

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,8 +1,7 @@
 en:
   theme_metadata:
-    custom_header_links: "Comma delimited in this order: link text, link title, URL, view, target, hide on scroll<br><b>Link text:</b> The text for the link<br><b>Link title:</b> the text that shows when the link is hovered<br><b>URL:</b> The path for the link (can be relative)<br><b>View:</b> vdm = desktop and mobile, vdo = desktop only, vmo = mobile only<br><b>Target:</b> blank = opens in a new tab, self = opens in the same tab<br><b>Hide on scroll:</b> remove = hides the link when the title is expanded on topic pages keep = keeps the link visible even when the title is visible on topic pages<br><b>Language:</b> blank = no locale assoaciated to the link, else insert a locale code (en, fr, de, ...)"
     settings:
-      Header_links:
+      header_links:
         description: Custom links to be displayed in the header
         schema:
           properties:

--- a/migrations/settings/0001-migrate-to-object-settings.js
+++ b/migrations/settings/0001-migrate-to-object-settings.js
@@ -27,6 +27,8 @@ export default function migrate(settings) {
     return newLink;
   });
 
-  settings.set("Header_links", newSetting);
+  settings.delete("Header_links");
+
+  settings.set("header_links", newSetting);
   return settings;
 }

--- a/migrations/settings/0001-migrate-to-object-settings.js
+++ b/migrations/settings/0001-migrate-to-object-settings.js
@@ -1,0 +1,32 @@
+export default function migrate(settings) {
+  const oldSetting = settings.get("Header_links");
+
+  if (!oldSetting) {
+    return settings;
+  }
+
+  const newSetting = oldSetting.split("|").map((link) => {
+    const [title, icon, url, view, target] = link
+      .split(",")
+      .map((s) => s.trim());
+
+    const newLink = {
+      title,
+      icon,
+      url,
+      view,
+      target,
+    };
+
+    Object.keys(newLink).forEach((key) => {
+      if (newLink[key] === undefined) {
+        delete newLink[key];
+      }
+    });
+
+    return newLink;
+  });
+
+  settings.set("Header_links", newSetting);
+  return settings;
+}

--- a/settings.yml
+++ b/settings.yml
@@ -9,7 +9,7 @@ Svg_icons:
   default: "fab-facebook|fab-twitter"
   description:
     en: "Include FontAwesome 5 icon classes for each icon used in the list."
-Header_links:
+header_links:
   type: objects
   default:
     - title: "Desktop and mobile link"

--- a/settings.yml
+++ b/settings.yml
@@ -1,21 +1,3 @@
-Header_links:
-  type: list
-  default: "Desktop mobile link, fab-facebook, https://facebook.com, vdm, blank|Mobile-only link, fab-twitter, https://twitter.com, vmo, blank"
-  description:
-    en: "Comma delimited in this order: <br>
-      <b>title, icon, URL, view, target</b>
-      <br>
-      <br>
-      <b>title</b>: the desired title you want the link to have (when hovered). <br>
-      <b>icon</b>: the icon you want the link to have. <br>
-      <b>URL</b>: the desired URL you want the link to point to. <br>
-      <b>View</b>:
-      <ul>
-      <li>visible on both desktop and mobile devices (vdm)</li>
-      <li>Desktop only (vdo).</li>
-      <li>mobile only (vmo).</li>
-      </ul>
-      <b>Target</b>: same tab (self) or new tab (blank)."
 add_whitespace:
   type: bool
   default: false
@@ -27,3 +9,49 @@ Svg_icons:
   default: "fab-facebook|fab-twitter"
   description:
     en: "Include FontAwesome 5 icon classes for each icon used in the list."
+Header_links:
+  type: objects
+  default:
+    - title: "Desktop and mobile link"
+      icon: "fab-facebook"
+      url: "https://facebook.com"
+      view: "vdm"
+      target: "blank"
+    - title: "Mobile-only link"
+      icon: "fab-twitter"
+      url: "https://twitter.com"
+      view: "vmo"
+      target: "blank"
+  schema:
+    name: "link"
+    properties:
+      title:
+        type: string
+        required: true
+        validations:
+          min_length: 1
+          max_length: 1000
+      icon:
+        type: string
+        required: true
+        validations:
+          min_length: 1
+          max_length: 100
+      url:
+        type: string
+        required: true
+        validations:
+          min_length: 1
+          max_length: 2048
+          url: true
+      view:
+        type: enum
+        choices:
+          - vdm
+          - vdo
+          - vmo
+      target:
+        type: enum
+        choices:
+          - blank
+          - self

--- a/spec/system/discourse_icon_header_links_spec.rb
+++ b/spec/system/discourse_icon_header_links_spec.rb
@@ -1,0 +1,51 @@
+RSpec.describe "Discourse icon header links", system: true do
+  let(:theme) { Fabricate(:theme) }
+  let!(:component) { upload_theme_component(parent_theme_id: theme.id) }
+
+  before { theme.set_default! }
+
+  context "when in desktop" do
+    it "renders the correct icon" do
+      visit("/")
+
+      expect(
+        page.find(
+          ".custom-header-icon-link.header-icon-desktop-and-mobile-link.vdm.last-custom-icon",
+        ),
+      ).to have_link(
+        title: "Desktop and mobile link",
+        href: "https://facebook.com",
+        target: "_blank",
+      )
+      expect(
+        page.find(
+          ".custom-header-icon-link.header-icon-desktop-and-mobile-link.vdm.last-custom-icon",
+        ),
+      ).to have_selector(".d-icon-fab-facebook")
+    end
+  end
+
+  context "when in mobile", mobile: true do
+    it "renders the correct icon" do
+      visit("/")
+
+      expect(
+        page.find(".custom-header-icon-link.header-icon-desktop-and-mobile-link.vdm"),
+      ).to have_link(
+        title: "Desktop and mobile link",
+        href: "https://facebook.com",
+        target: "_blank",
+      )
+      expect(
+        page.find(".custom-header-icon-link.header-icon-desktop-and-mobile-link.vdm"),
+      ).to have_selector(".d-icon-fab-facebook")
+
+      expect(
+        page.find(".custom-header-icon-link.header-icon-mobile-only-link.vmo.last-custom-icon"),
+      ).to have_link(title: "Mobile-only link", href: "https://twitter.com", target: "_blank")
+      expect(
+        page.find(".custom-header-icon-link.header-icon-mobile-only-link.vmo.last-custom-icon"),
+      ).to have_selector(".d-icon-fab-twitter")
+    end
+  end
+end

--- a/test/unit/migrations/settings/0001-migrate-to-object-settings-test.js
+++ b/test/unit/migrations/settings/0001-migrate-to-object-settings-test.js
@@ -8,7 +8,7 @@ module(
       const settings = new Map(
         Object.entries({
           Header_links:
-            "Desktop mobile link, fab-facebook, https://facebook.com, vdm, blank|Mobile-only link, fab-twitter, https://twitter.com, vmo, blank",
+            "Desktop and mobile link, fab-facebook, https://facebook.com, vdm, blank|Mobile-only link, fab-twitter, https://twitter.com, vmo, blank",
         })
       );
 
@@ -16,7 +16,7 @@ module(
 
       const expectedResult = new Map(
         Object.entries({
-          Header_links: [
+          header_links: [
             {
               icon: "fab-facebook",
               title: "Desktop and mobile link",

--- a/test/unit/migrations/settings/0001-migrate-to-object-settings-test.js
+++ b/test/unit/migrations/settings/0001-migrate-to-object-settings-test.js
@@ -1,0 +1,41 @@
+import { module, test } from "qunit";
+import migrate from "../../../../migrations/settings/0001-migrate-to-object-settings";
+
+module(
+  "Unit | Migrations | Settings | 0001-migrate-to-object-settings",
+  function () {
+    test("migrate", function (assert) {
+      const settings = new Map(
+        Object.entries({
+          Header_links:
+            "Desktop mobile link, fab-facebook, https://facebook.com, vdm, blank|Mobile-only link, fab-twitter, https://twitter.com, vmo, blank",
+        })
+      );
+
+      const result = migrate(settings);
+
+      const expectedResult = new Map(
+        Object.entries({
+          Header_links: [
+            {
+              icon: "fab-facebook",
+              title: "Desktop and mobile link",
+              url: "https://facebook.com",
+              view: "vdm",
+              target: "blank",
+            },
+            {
+              icon: "fab-twitter",
+              title: "Mobile-only link",
+              url: "https://twitter.com",
+              view: "vmo",
+              target: "blank",
+            },
+          ],
+        })
+      );
+
+      assert.deepEqual(Array.from(result), Array.from(expectedResult));
+    });
+  }
+);


### PR DESCRIPTION
Prior to this commit the setting was only a string split at runtime on a | separator. This is now using our object settings and can be modifier more easily by ours users using the object editor.

This commit also
- fixes a bug where we were rendering, and only hiding mobile icons on desktop when using (vmo) which was causing the "last-custom-icon" class to be incorrectly set on an hidden icon
- adds a system spec